### PR TITLE
Runkeeper

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,25 +11,27 @@ gem 'devise', '2.2.3'
 gem 'bullet', group: :development
 
 gem 'omniauth'
-gem 'omniauth-twitter' 
-gem 'omniauth-github' 
+gem 'omniauth-twitter'
+gem 'omniauth-github'
 
 gem 'figaro'
 
-group:development, :test do
+group :development, :test do
   gem "rspec-rails", "~> 2.12.2"
-  gem "factory_girl_rails", "~> 4.2.0" 
+  gem "factory_girl_rails", "~> 4.2.0"
   gem "guard-rspec", "~> 2.4.0"
+  gem "quiet_assets"
   gem "pry", '0.9.12'
 end
 
-group:test do
+group :test do
   gem "faker", "~> 1.1.2"
   gem 'cucumber-rails', '1.3.1', :require => false
   gem "capybara", "~> 2.0.2"
-  gem "database_cleaner", "~> 0.9.1" 
+  gem "database_cleaner", "~> 0.9.1"
   gem "launchy", "~> 2.2.0"
   gem "email_spec", "1.4.0"
+  gem "webmock"
 end
 
 

--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ gem 'bullet', group: :development
 gem 'omniauth'
 gem 'omniauth-twitter'
 gem 'omniauth-github'
-
+gem 'sidekiq'
 gem 'figaro'
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -52,6 +52,7 @@ GEM
       execjs
     coffee-script-source (1.6.2)
     commonjs (0.2.6)
+    crack (0.3.2)
     cucumber (1.3.1)
       builder (>= 2.1.2)
       diff-lcs (>= 1.1.3)
@@ -162,6 +163,8 @@ GEM
       coderay (~> 1.0.5)
       method_source (~> 0.8)
       slop (~> 3.4)
+    quiet_assets (1.0.2)
+      railties (>= 3.1, < 5.0)
     rack (1.4.5)
     rack-cache (1.2)
       rack (>= 0.4)
@@ -244,6 +247,9 @@ GEM
     uniform_notifier (1.2.0)
     warden (1.2.1)
       rack (>= 1.0)
+    webmock (1.11.0)
+      addressable (>= 2.2.7)
+      crack (>= 0.3.2)
     websocket (1.0.7)
     xpath (1.0.0)
       nokogiri (~> 1.3)
@@ -271,9 +277,11 @@ DEPENDENCIES
   omniauth-twitter
   pg (= 0.14.1)
   pry (= 0.9.12)
+  quiet_assets
   rails (= 3.2.11)
   rspec-rails (~> 2.12.2)
   sass-rails (~> 3.2.3)
   therubyracer
   twitter-bootstrap-rails
   uglifier (>= 1.0.3)
+  webmock

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,6 +41,8 @@ GEM
       rack-test (>= 0.5.4)
       selenium-webdriver (~> 2.0)
       xpath (~> 1.0.0)
+    celluloid (0.14.0)
+      timers (>= 1.0.0)
     childprocess (0.3.9)
       ffi (~> 1.0, >= 1.0.11)
     coderay (1.0.9)
@@ -52,6 +54,7 @@ GEM
       execjs
     coffee-script-source (1.6.2)
     commonjs (0.2.6)
+    connection_pool (1.0.0)
     crack (0.3.2)
     cucumber (1.3.1)
       builder (>= 2.1.2)
@@ -195,6 +198,9 @@ GEM
       ffi (>= 0.5.0)
     rdoc (3.12.2)
       json (~> 1.4)
+    redis (3.0.4)
+    redis-namespace (1.3.0)
+      redis (~> 3.0.0)
     ref (1.0.4)
     rspec (2.12.0)
       rspec-core (~> 2.12.0)
@@ -222,6 +228,12 @@ GEM
       multi_json (~> 1.0)
       rubyzip
       websocket (~> 1.0.4)
+    sidekiq (2.11.2)
+      celluloid (>= 0.13.0)
+      connection_pool (>= 1.0.0)
+      multi_json
+      redis (>= 3.0)
+      redis-namespace
     slop (3.4.4)
     sprockets (2.2.2)
       hike (~> 1.2)
@@ -233,6 +245,7 @@ GEM
       ref
     thor (0.18.1)
     tilt (1.4.0)
+    timers (1.1.0)
     treetop (1.4.12)
       polyglot
       polyglot (>= 0.3.1)
@@ -281,6 +294,7 @@ DEPENDENCIES
   rails (= 3.2.11)
   rspec-rails (~> 2.12.2)
   sass-rails (~> 3.2.3)
+  sidekiq
   therubyracer
   twitter-bootstrap-rails
   uglifier (>= 1.0.3)

--- a/app/controllers/users/auth_callbacks_controller.rb
+++ b/app/controllers/users/auth_callbacks_controller.rb
@@ -1,0 +1,21 @@
+class Users::AuthCallbacksController < ApplicationController
+  def run_keeper_auth
+    if params[:code].present?
+      token_fetcher = RunKeeperTokenFetcher.new(self, params[:code])
+      access_token = token_fetcher.fetch_access_token
+    else
+      render nothing: true
+    end
+  end
+
+  def fetched_runkeeper_token(access_token)
+    flash[:notice] = "Your account has been linked to your Runkeeper account. We will be downloading your fitness activities from Runkeeper periodically."
+    current_user.update_attributes(runkeeper_token: access_token)
+    redirect_to current_user
+  end
+
+  def runkeeper_token_error
+    flash[:error] = "Some problems prevented from linking your account with your Runkeeper account."
+    redirect_to current_user
+  end
+end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,2 +1,8 @@
 module UsersHelper
+  def runkeeper_auth_endpoint
+    params = "client_id=#{RunKeeper::CLIENT_ID}"
+    params += "&" + "response_type=code"
+    params += "&" + "redirect_uri=#{CGI.escape(RunKeeper::REDIRECT_URI)}"
+    RunKeeper::AUTHORIZATION_URL + "?#{params}"
+  end
 end

--- a/app/models/entry.rb
+++ b/app/models/entry.rb
@@ -6,5 +6,28 @@ class Entry < ActiveRecord::Base
   validates :time, :presence => { :unless => :distance, :message => "You must enter distance or time or both." }
   validates :user, :presence => true
 
+  def self.create_entry_from_runkeeper(activity, user)
+    entry = Entry.new
+    entry.distance = activity["total_distance"].to_f / 1000.0
+    entry.time = activity["duration"].to_i / 60
+    entry.entry_mode = "run_keeper"
+    entry.user = user
+    entry.description = activity["type"]
+    entry.start_time = activity["start_time"]
+    entry.source_id = activity["uri"]
+    unless Entry.where(entry_mode: entry.entry_mode, source_id: entry.source_id).any?
+      entry.save
+    end
+    entry
+  end
+
+  def runkeeper_entry_present?(entry)
+    Entry.where(entry_mode: "run_keeper", source_id: entry.source_id).any?
+  end
+
+  def self.update_entry(entry, user)
+    Entry.where()
+  end
+
   attr_accessible :description, :distance, :location, :time, :user
 end

--- a/app/models/run_keeper/fitness_activity_updater.rb
+++ b/app/models/run_keeper/fitness_activity_updater.rb
@@ -1,0 +1,13 @@
+class RunKeeper::FitnessActivityUpdater
+  attr_accessor :feed
+  def update_entries_for(user)
+    feed.activities(user).each do |activity|
+      Entry.create_entry_from_runkeeper(activity, user)
+    end
+  end
+
+  private
+  def feed
+    @feed ||= RunKeeper::FitnessFeed.new
+  end
+end

--- a/app/models/run_keeper/fitness_feed.rb
+++ b/app/models/run_keeper/fitness_feed.rb
@@ -1,0 +1,19 @@
+class RunKeeper::FitnessFeed
+  def activities(user, no_earlier_than=Date.today - 1)
+    uri = URI(RunKeeper::API_END_POINT + "/fitnessActivities")
+    http = Net::HTTP.new(uri.host, uri.port)
+    http.use_ssl = true
+    no_earlier_than_formatted = no_earlier_than.strftime("%Y-%m-%d")
+    http.start do |h|
+      request = Net::HTTP::Get.new "/fitnessActivities?noEarlierThan=#{no_earlier_than_formatted}"
+      request["Authorization"] = "Bearer #{user.runkeeper_token}"
+      request["Accept"] = "application/vnd.com.runkeeper.FitnessActivityFeed+json"
+      resp = h.request(request)
+      if resp.code == "200"
+        JSON.parse(resp.body)["items"]
+      else
+        []
+      end
+    end
+  end
+end

--- a/app/models/run_keeper_token_fetcher.rb
+++ b/app/models/run_keeper_token_fetcher.rb
@@ -1,0 +1,30 @@
+class RunKeeperTokenFetcher < Struct.new(:listener, :code)
+  def fetch_access_token
+    http = Net::HTTP.new(uri.host, uri.port)
+    request = Net::HTTP::Post.new(uri.request_uri)
+    request.set_form_data(payload)
+    http.use_ssl = true
+    request["Content-Type"] = "application/x-www-form-urlencoded"
+    response = http.request(request)
+    response_json = JSON.parse(response.body)
+    if response_json["access_token"].present?
+      listener.fetched_runkeeper_token(response_json["access_token"])
+    else
+      listener.runkeeper_token_error
+    end
+  end
+
+  def uri
+    URI.parse(RunKeeper::ACCESS_TOKEN_URL)
+  end
+
+  def payload
+    {
+      grant_type: 'authorization_code',
+      code: code,
+      client_id: RunKeeper::CLIENT_ID,
+      client_secret: RunKeeper::CLIENT_SECRET,
+      redirect_uri:  RunKeeper::REDIRECT_URI
+    }
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -46,4 +46,7 @@ class User < ActiveRecord::Base
     user if user && user.last_name == name_parts[1]
   end
 
+  def self.runkeepers
+    User.where("runkeeper_token is not null")
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,8 +3,8 @@ class User < ActiveRecord::Base
 
   has_many :entries
   # Include default devise modules. Others available are:
-  # :token_authenticatable, 
-  # :lockable, :timeoutable 
+  # :token_authenticatable,
+  # :lockable, :timeoutable
   devise :database_authenticatable, :registerable, :confirmable,
          :recoverable, :rememberable, :trackable, :validatable,
          :omniauthable
@@ -12,10 +12,10 @@ class User < ActiveRecord::Base
   # Setup accessible (or protected) attributes for your model
   attr_accessible :email, :password, :password_confirmation, :remember_me,
                   :first_name, :last_name,
-                  :running_in_pune, :runner_goal, :runner_level
+                  :running_in_pune, :runner_goal, :runner_level, :runkeeper_token
   # attr_accessible :title, :body
 
-  def display_name 
+  def display_name
     if twitter_id
       "#{twitter_display_name} (@#{twitter_screen_name})"
     elsif github_id

--- a/app/views/users/_user.html.erb
+++ b/app/views/users/_user.html.erb
@@ -45,6 +45,9 @@
     <%= link_to "Change password",
       edit_user_registration_path,
       :class => 'btn btn-primary' %>
+    <%= link_to "Link with Runkeeper",
+        runkeeper_auth_endpoint,
+      :class => 'btn btn-primary' %>
   <% end %>
 
 <br><br><br>

--- a/app/worker/runkeeper_activity_feed_worker.rb
+++ b/app/worker/runkeeper_activity_feed_worker.rb
@@ -1,0 +1,12 @@
+class RunkeeperActivityFeedWorker
+  include Sidekiq::Worker
+  def perform
+    User.runkeepers.each do |user|
+      fitness_activity_updater.update_entries_for(user)
+    end
+  end
+
+  def fitness_activity_updater
+    @fa ||= RunKeeper::FitnessActivityUpdater.new
+  end
+end

--- a/config/initializers/auth_settings.rb
+++ b/config/initializers/auth_settings.rb
@@ -1,0 +1,12 @@
+module RunKeeper
+  if Rails.env.production?
+    REDIRECT_URI = "http://ruby5k.in/auth_callbacks/run_keeper_auth".freeze
+  else
+    REDIRECT_URI = "http://localhost:3000/auth_callbacks/run_keeper_auth".freeze
+  end
+  AUTHORIZATION_URL = 'https://runkeeper.com/apps/authorize'.freeze
+  API_END_POINT = 'https://api.runkeeper.com'.freeze
+  ACCESS_TOKEN_URL = 'https://runkeeper.com/apps/token'.freeze
+  CLIENT_ID = ENV['RUNKEEPER_CLIENT_ID']
+  CLIENT_SECRET = ENV['RUNKEEPER_CLIENT_SECRET']
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 Ruby5kdev::Application.routes.draw do
   match 'contact_us' => 'misc#contact_us', :as => :contact_us
   match 'newcomers'  => 'misc#newcomers',  :as => :newcomers
+  match "auth_callbacks/run_keeper_auth" => "users/auth_callbacks#run_keeper_auth"
 
   devise_for :users, :controllers => {
     :omniauth_callbacks => "users/omniauth_callbacks"

--- a/db/migrate/20130508120959_add_runkeeper_token_to_users.rb
+++ b/db/migrate/20130508120959_add_runkeeper_token_to_users.rb
@@ -1,0 +1,5 @@
+class AddRunkeeperTokenToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :runkeeper_token, :string
+  end
+end

--- a/db/migrate/20130509183404_add_cols_to_entries.rb
+++ b/db/migrate/20130509183404_add_cols_to_entries.rb
@@ -1,0 +1,7 @@
+class AddColsToEntries < ActiveRecord::Migration
+  def change
+    add_column :entries, :entry_mode, :string
+    add_column :entries, :start_time, :timestamp
+    add_column :entries, :source_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20130508120959) do
+ActiveRecord::Schema.define(:version => 20130509183404) do
 
   create_table "comments", :force => true do |t|
     t.text     "text"
@@ -29,6 +29,9 @@ ActiveRecord::Schema.define(:version => 20130508120959) do
     t.datetime "created_at",  :null => false
     t.datetime "updated_at",  :null => false
     t.integer  "user_id"
+    t.string   "entry_mode"
+    t.datetime "start_time"
+    t.string   "source_id"
   end
 
   create_table "users", :force => true do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20130506034128) do
+ActiveRecord::Schema.define(:version => 20130508120959) do
 
   create_table "comments", :force => true do |t|
     t.text     "text"
@@ -60,6 +60,7 @@ ActiveRecord::Schema.define(:version => 20130506034128) do
     t.string   "github_user_name"
     t.string   "github_display_name"
     t.string   "avatar_url"
+    t.string   "runkeeper_token"
   end
 
   add_index "users", ["email"], :name => "index_users_on_email", :unique => true

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,9 +1,14 @@
 # Read about factories at https://github.com/thoughtbot/factory_girl
 
 FactoryGirl.define do
+  sequence(:email) { |n| "email#{n}@ruby5k.com" }
   factory :user do
-    sequence(:email) { |n| "email#{n}@ruby5k.com" }
+    email { FactoryGirl.generate :email }
     password "password"
     password_confirmation { |x| x.password }
+    trait :runkeeper do
+      runkeeper_token "THE_TOKEN"
+    end
+    factory :runkeeper_user, traits: [:runkeeper]
   end
 end

--- a/spec/helpers/users_helper_spec.rb
+++ b/spec/helpers/users_helper_spec.rb
@@ -1,14 +1,11 @@
 require 'spec_helper'
-
-# Specs in this file have access to a helper object that includes
-# the UsersHelper. For example:
-#
-# describe UsersHelper do
-#   describe "string concat" do
-#     it "concats two strings with spaces" do
-#       helper.concat_strings("this","that").should == "this that"
-#     end
-#   end
-# end
 describe UsersHelper do
+  describe "runkeeper_auth_endpoint" do
+    it "fetches valid URL with params for endpoint" do
+      params = "client_id=#{RunKeeper::CLIENT_ID}"
+      params += "&" + "response_type=code"
+      params += "&" + "redirect_uri=#{CGI.escape(RunKeeper::REDIRECT_URI)}"
+      helper.runkeeper_auth_endpoint.should eq(RunKeeper::AUTHORIZATION_URL + "?" + params)
+    end
+  end
 end

--- a/spec/models/entry_spec.rb
+++ b/spec/models/entry_spec.rb
@@ -29,4 +29,56 @@ describe Entry do
     entry.should be_valid
   end
 
+  describe "Entry from Runkeeper" do
+    before do
+      @activity = {
+        "total_distance" => "1200.0",
+        "duration" => "2400",
+        "type" => "Running",
+        "start_time" => "Wed, 8 May 2013 06:50:00",
+        "uri" => "/f/12345"
+      }
+      @user = User.new
+    end
+    subject { Entry.create_entry_from_runkeeper(@activity, @user) }
+    it "creates a new instance of entry" do
+      subject.should be_instance_of(Entry)
+    end
+    it "converts duration to minutes from seconds" do
+      subject.time.should eq(40)
+    end
+    it "converts distance to km from metres" do
+      subject.distance.should eq(1.2)
+    end
+    it "converts start_time to correct format" do
+      subject.start_time.day.should == 8
+      subject.start_time.month.should == 5
+      subject.start_time.year.should == 2013
+    end
+    it "assigns user" do
+      subject.user.should eq(@user)
+    end
+    it "sets the entry mode" do
+      subject.entry_mode.should eq("run_keeper")
+    end
+    it "sets the source_id" do
+      subject.source_id.should eq(@activity["uri"])
+    end
+    context "persist the entry" do
+      before do
+        @user = FactoryGirl.create(:user)
+      end
+      it "saves the entry to db" do
+        subject.should be_persisted
+      end
+    end
+    context "entry already present" do
+      before do
+        FactoryGirl.create(:entry, entry_mode: "run_keeper", source_id: "/f/12345")
+      end
+      it "saves the entry to db" do
+        subject.should_not be_persisted
+      end
+    end
+  end
 end

--- a/spec/models/run_keeper/fitness_feed_spec.rb
+++ b/spec/models/run_keeper/fitness_feed_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+
+describe RunKeeper::FitnessFeed do
+  subject { described_class.new }
+  let(:user) { stub(:user, runkeeper_token: "THE_TOKEN") }
+
+  context "fetch fitness activities of user" do
+    before do
+      response = "{\"items\":[{\"duration\":600,\"total_distance\":1455.16890742677,\"has_path\":true,\"entry_mode\":\"Web\",\"source\":\"RunKeeper\",\"start_time\":\"Thu, 9 May 2013 11:54:00\",\"type\":\"Running\",\"uri\":\"/fitnessActivities/178338392\"},{\"duration\":1200,\"total_distance\":3000,\"has_path\":false,\"entry_mode\":\"Web\",\"source\":\"RunKeeper\",\"start_time\":\"Wed, 8 May 2013 06:50:00\",\"type\":\"Running\",\"uri\":\"/fitnessActivities/177697803\"}],\"size\":2}"
+      stub_request(:get, "https://api.runkeeper.com/fitnessActivities?noEarlierThan=2013-05-10").
+         with(:headers => {'Accept'=>'application/vnd.com.runkeeper.FitnessActivityFeed+json', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer THE_TOKEN', 'User-Agent'=>'Ruby'}).
+        to_return(:status => 200, :body => response, :headers => {})
+    end
+
+    it "returns array of users past activity" do
+      subject.activities(user, Date.new(2013, 5, 10)).count.should == 2
+    end
+  end
+
+  context "error in fetch fitness activities of user" do
+    before do
+      stub_request(:get, "https://api.runkeeper.com/fitnessActivities?noEarlierThan=2013-05-10").
+         with(:headers => {'Accept'=>'application/vnd.com.runkeeper.FitnessActivityFeed+json', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer THE_TOKEN', 'User-Agent'=>'Ruby'}).
+        to_return(:status => 406, :body => "", :headers => {})
+    end
+
+    it "returns an empty array" do
+      subject.activities(user, Date.new(2013, 5, 10)).should eq([])
+    end
+  end
+end

--- a/spec/models/run_keeper_token_fetcher_spec.rb
+++ b/spec/models/run_keeper_token_fetcher_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+
+describe RunKeeperTokenFetcher do
+
+  let(:listener) { stub(:listener).as_null_object }
+  let(:code) { "THE_CODE" }
+
+  before do
+    @it = described_class.new(listener, code)
+  end
+
+  context "fetch access token" do
+    before do
+      stub_request(:post, RunKeeper::ACCESS_TOKEN_URL).
+        with(body: {client_id: RunKeeper::CLIENT_ID, client_secret: RunKeeper::CLIENT_SECRET, code: code, grant_type: "authorization_code", redirect_uri: RunKeeper::REDIRECT_URI},
+        :headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Content-Type'=>'application/x-www-form-urlencoded', 'User-Agent'=>'Ruby'}).
+        to_return(:status => 200, :body => "{\"access_token\":\"THE_TOKEN\"}", :headers => {})
+    end
+    it "passes the token to listener" do
+      listener.should_receive(:fetched_runkeeper_token).with("THE_TOKEN")
+      @it.fetch_access_token
+    end
+  end
+
+  context "could not fetch access token" do
+    before do
+      stub_request(:post, RunKeeper::ACCESS_TOKEN_URL).
+        with(body: {client_id: RunKeeper::CLIENT_ID, client_secret: RunKeeper::CLIENT_SECRET, code: code, grant_type: "authorization_code", redirect_uri: RunKeeper::REDIRECT_URI},
+        :headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Content-Type'=>'application/x-www-form-urlencoded', 'User-Agent'=>'Ruby'}).
+        to_return(:status => 404, :body => "{}", :headers => {})
+    end
+    it "passes token not fetched message to listener" do
+      listener.should_receive(:runkeeper_token_error).with(no_args)
+      @it.fetch_access_token
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,11 +1,20 @@
 require 'spec_helper'
 
 describe User do
-  describe "name= method" do
-    before :each do
-      @user = FactoryGirl.create(:user)
-    end
+  before :each do
+    @user = FactoryGirl.create(:user)
+  end
 
+  describe "runkeeper users" do
+    before do
+      FactoryGirl.create(:user, runkeeper_token: "foobar")
+    end
+    it "fetches all users who are linked to runkeeper" do
+      User.runkeepers.count.should == 1
+    end
+  end
+
+  describe "name= method" do
     it "should split the name into first_name and last_name" do
       @user.name = "Ashis Roy"
       @user.first_name.should eq( "Ashis" )

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,7 +2,7 @@
 ENV["RAILS_ENV"] ||= 'test'
 require File.expand_path("../../config/environment", __FILE__)
 require 'rspec/rails'
-require 'rspec/autorun'
+#require 'rspec/autorun'
 require 'webmock/rspec'
 # Requires supporting ruby files with custom matchers and macros, etc,
 # in spec/support/ and its subdirectories.
@@ -23,8 +23,19 @@ RSpec.configure do |config|
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false
   # instead of true.
-  config.use_transactional_fixtures = true
+  config.use_transactional_fixtures = false
+  config.before(:suite) do
+    DatabaseCleaner.strategy = :transaction
+    DatabaseCleaner.clean_with(:truncation)
+  end
 
+  config.before(:each) do
+    DatabaseCleaner.start
+  end
+
+  config.after(:each) do
+    DatabaseCleaner.clean
+  end
   # If true, the base class of anonymous controllers will be inferred
   # automatically. This will be the default behavior in future versions of
   # rspec-rails.

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,7 +3,7 @@ ENV["RAILS_ENV"] ||= 'test'
 require File.expand_path("../../config/environment", __FILE__)
 require 'rspec/rails'
 require 'rspec/autorun'
-
+require 'webmock/rspec'
 # Requires supporting ruby files with custom matchers and macros, etc,
 # in spec/support/ and its subdirectories.
 Dir[Rails.root.join("spec/support/**/*.rb")].each {|f| require f}

--- a/spec/worker/runkeeper_activity_feed_worker_spec.rb
+++ b/spec/worker/runkeeper_activity_feed_worker_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+require 'sidekiq/testing'
+
+describe RunkeeperActivityFeedWorker do
+  before do
+    FactoryGirl.create(:user)
+    FactoryGirl.create(:runkeeper_user)
+    @worker = described_class.new
+    date = (Date.today - 1).strftime("%Y-%m-%d")
+    response = "{\"items\":[{\"duration\":600,\"total_distance\":1455.16890742677,\"start_time\":\"Thu, 9 May 2013 11:54:00\",\"type\":\"Running\",\"uri\":\"/fitnessActivities/178338392\"}]}"
+    stub_request(:get, "https://api.runkeeper.com/fitnessActivities?noEarlierThan=#{date}").
+      with(:headers => {'Accept'=>'application/vnd.com.runkeeper.FitnessActivityFeed+json', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer THE_TOKEN', 'User-Agent'=>'Ruby'}).
+      to_return(:status => 200, :body => response, :headers => {})
+  end
+
+  it "updates users training entried" do
+    lambda do
+      @worker.perform
+    end.should change(Entry,:count).by(1)
+  end
+
+  it "updates job queue" do
+    expect {
+      described_class.perform_async
+    }.to change(described_class.jobs, :size).by(1)
+  end
+end


### PR DESCRIPTION
## Integration with runkeeper

You need to
- Create account in [Runkeeper](http://runkeeper.com/)
- Have to register ruby5k as app in [Runkeeper Partner Portal](http://runkeeper.com/partner)
- While registering app choose 
  *\* Category as Activity Tracking
  *\* Check Read Health Information
  *\* Check Retain Health Information
- Note down CLIENT_ID and CLIENT_SECRET
- Create two environment variable RUNKEEPER_CLIENT_ID and RUNKEEPER_CLIENT_SECRET and assign values from above

Once that is done you can visit Users profile page in ruby5k which will have Link to Runkeeper link for associating ruby5k and runkeeper accounts

I have also done a Sidekiq Job for scanning Users activity feeds in Runkeeper and updating Entry table in ruby5k

So in Heroku you need to
- Add the required environment variable
- Add sidekiq and redis
- [Schedule the job](https://devcenter.heroku.com/articles/scheduler)

Looks like you may incur cost for running scheduler (see the above link). 

Let me know if you need more clarifications or help.
